### PR TITLE
Added return type to jwt_generator.build_jwt()

### DIFF
--- a/coinbase/jwt_generator.py
+++ b/coinbase/jwt_generator.py
@@ -7,7 +7,7 @@ from cryptography.hazmat.primitives import serialization
 from coinbase.constants import BASE_URL, REST_SERVICE, WS_SERVICE
 
 
-def build_jwt(key_var, secret_var, service, uri=None):
+def build_jwt(key_var, secret_var, service, uri=None) -> str:
     try:
         private_key_bytes = secret_var.encode("utf-8")
         private_key = serialization.load_pem_private_key(


### PR DESCRIPTION
Types should be defined wherever possible. This helps users of the SDK know what is required and expected. User's IDEs/editors will often show them what types are returned or expected. The more types there are, the more mypy can validate them in this project and thus validate more of the code in this project. This will also help users of mypy in their own projects that use this SDK to know what types are required.