### PR TITLE
Modify RESTClient post() to add CB-2FA-Token for SIWC transaction endpoints

### DIFF
--- a/coinbase/api_base.py
+++ b/coinbase/api_base.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import IO, Optional, Union
 
-from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY
+from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY, CB_2FA_TOKEN_ENV_KEY
 
 
 def get_logger(name):
@@ -26,6 +26,7 @@ class APIBase(object):
         api_key: Optional[str] = os.getenv(API_ENV_KEY),
         api_secret: Optional[str] = os.getenv(API_SECRET_ENV_KEY),
         key_file: Optional[Union[IO, str]] = None,
+        cb_2fa_token: Optional[str] = os.getenv(CB_2FA_TOKEN_ENV_KEY),
         base_url=None,
         timeout: Optional[int] = None,
         verbose: Optional[bool] = False,
@@ -55,5 +56,6 @@ class APIBase(object):
             )
         self.api_key = api_key
         self.api_secret = bytes(api_secret, encoding="utf8").decode("unicode_escape")
+        self.cb_2fa_token = cb_2fa_token
         self.base_url = base_url
         self.timeout = timeout

--- a/coinbase/constants.py
+++ b/coinbase/constants.py
@@ -2,6 +2,7 @@ from coinbase.__version__ import __version__
 
 API_ENV_KEY = "COINBASE_API_KEY"
 API_SECRET_ENV_KEY = "COINBASE_API_SECRET"
+CB_2FA_TOKEN_ENV_KEY = "CB_2FA_TOKEN"
 USER_AGENT = f"coinbase-advanced-py/{__version__}"
 
 # REST Constants

--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 from coinbase import jwt_generator
 from coinbase.api_base import APIBase, get_logger
-from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY, BASE_URL, USER_AGENT
+from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY, CB_2FA_TOKEN_ENV_KEY, BASE_URL, USER_AGENT
 
 logger = get_logger("coinbase.RESTClient")
 
@@ -54,6 +54,7 @@ class RESTBase(APIBase):
     - **api_key | Optional (str)** - The API key
     - **api_secret | Optional (str)** - The API key secret
     - **key_file | Optional (IO | str)** - Path to API key file or file-like object
+    - **cb_2fa_token | Optional (str)** - The 2FA token required for some send transactions
     - **base_url | (str)** - The base URL for REST requests. Default set to "https://api.coinbase.com"
     - **timeout | Optional (int)** - Set timeout in seconds for REST requests
     - **verbose | Optional (bool)** - Enables debug logging. Default set to False
@@ -66,6 +67,7 @@ class RESTBase(APIBase):
         api_key: Optional[str] = os.getenv(API_ENV_KEY),
         api_secret: Optional[str] = os.getenv(API_SECRET_ENV_KEY),
         key_file: Optional[Union[IO, str]] = None,
+        cb_2fa_token: Optional[str] = os.getenv(CB_2FA_TOKEN_ENV_KEY),
         base_url=BASE_URL,
         timeout: Optional[int] = None,
         verbose: Optional[bool] = False,
@@ -74,6 +76,7 @@ class RESTBase(APIBase):
             api_key=api_key,
             api_secret=api_secret,
             key_file=key_file,
+            cb_2fa_token=cb_2fa_token,
             base_url=base_url,
             timeout=timeout,
             verbose=verbose,
@@ -247,6 +250,13 @@ class RESTBase(APIBase):
                     "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret)}",
                 }
                 if not public
+                else {}
+            ),
+            **(
+                {
+                    "CB-2FA-TOKEN": self.cb_2fa_token,
+                }
+                if self.cb_2fa_token
                 else {}
             ),
         }


### PR DESCRIPTION
With the [April 2nd expansion][a] of the CDP api keys to support SIWC urls, there is extra support needed for the `/v2/accounts/:account_id/transactions` endpoints.  This appears to be a holdover from the OAuth2 support, and may actually be an error in the API.  If not, support is needed for the `transactions` endpoints.  Specifically, posts this endpoint requires the `CB-2FA-Token` header.  This PR adds a `cb_2fa_token` argument to the `RESTClient` constructor to facilitate that.

[a]: https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/changelog#2024-apr-02

## Example

    from requests.exceptions import HTTPError
    from coinbase.rest import RESTClient

    params = {
      "type": "send",
      "currency": "BTC",
      "to": "bc1qwc2203uym96u0nmq04pcgqfs9ldqz9l3mz8fpj",
      "amount": "0.00045678",
    }

    api_key = "organizations/{org_id}/apiKeys/{key_id}"
    api_secret = "-----BEGIN EC PRIVATE KEY-----\nYOUR PRIVATE KEY\n-----END EC PRIVATE KEY-----\n"
    client = RESTClient(
        api_key = api_key,
        api_secret = api_secret,
    )
    try:
        client.post("/v2/accounts/456789ab-cdef-0123-4567-89abcdef0123/transactions", params)
    except HTTPError as e:
        if "two_factor_required" in e.args[0]:
            cb_2fa_token=input("CB-2FA-Token: ").strip()
            client = RESTClient(
                api_key = api_key,
                api_secret = api_secret,
                cb_2fa_token = cb_2fa_token,
            )
            client.post("/v2/accounts/456789ab-cdef-0123-4567-89abcdef0123/transactions", params)
        else:
            raise e



## Changes

  - Add `CB-2FA-TOKEN` header when `cb_2fa_token` is found in instance
  - Add `CB_2FA_TOKEN_ENV_KEY` constant
  - Add `cb_2fa_token` to APIBase constructor
  - Add `cb_2fa_token` to RESTClient constructor