### PR TITLE
Store asyncio.Task to Avoid GC

### DIFF
--- a/coinbase/websocket/websocket_base.py
+++ b/coinbase/websocket/websocket_base.py
@@ -118,7 +118,7 @@ class WSBase(APIBase):
         self.websocket = None
         self.loop = None
         self.thread = None
-        self._ws_task = None
+        self._task = None
 
         self.retry = retry
         self._retry_max_tries = WS_RETRY_MAX

--- a/coinbase/websocket/websocket_base.py
+++ b/coinbase/websocket/websocket_base.py
@@ -118,6 +118,7 @@ class WSBase(APIBase):
         self.websocket = None
         self.loop = None
         self.thread = None
+        self._ws_task = None
 
         self.retry = retry
         self._retry_max_tries = WS_RETRY_MAX
@@ -176,7 +177,7 @@ class WSBase(APIBase):
 
             # Start the message handler coroutine after establishing connection
             if not self._retrying:
-                asyncio.create_task(self._message_handler())
+                self._task = asyncio.create_task(self._message_handler())
         except asyncio.TimeoutError as toe:
             self.websocket = None
             logger.error("Connection attempt timed out: %s", toe)


### PR DESCRIPTION
I was looking through the websocket code recently and noticed that a `Task` was being created and not stored anywhere. The async docs call this out as a problem since created Tasks can be garbage-collected if they're not referenced by anything, thus stopping them mid-execution. 

I haven't seen this occur, but it's an easy fix to store it on the class, and from a quick reading I don't think it should have any side effects.

Link (second badge labeled "Important"): https://docs.python.org/3/library/asyncio-task.html#creating-tasks