### PR TITLE
Correct fees.py documentation link

### DIFF
--- a/coinbase/rest/fees.py
+++ b/coinbase/rest/fees.py
@@ -25,7 +25,7 @@ def get_transaction_summary(
 
     __________
 
-    **Read more on the official documentation:** `Create Convert Quote <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_createconvertquote>`_
+    **Read more on the official documentation:** `Get Transaction Summary <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_gettransactionsummary>`_
     """
     endpoint = f"{API_PREFIX}/transaction_summary"
 


### PR DESCRIPTION
The `coinbase/rest/feeds.py` file has an incorrect link to the API documentation. Looks like a copy and paste issue. This change points to the correct API documentation.