### PR TITLE
Add API Sandbox support

### DIFF
--- a/coinbase/constants.py
+++ b/coinbase/constants.py
@@ -6,6 +6,7 @@ USER_AGENT = f"coinbase-advanced-py/{__version__}"
 
 # REST Constants
 BASE_URL = "api.coinbase.com"
+SANDBOX_BASE_URL = "api-sandbox.coinbase.com"
 API_PREFIX = "/api/v3/brokerage"
 
 # Websocket Constants

--- a/coinbase/rest/__init__.py
+++ b/coinbase/rest/__init__.py
@@ -15,10 +15,14 @@ class RESTClient(RESTBase):
     - **api_key | Optional (str)** - The API key
     - **api_secret | Optional (str)** - The API key secret
     - **key_file | Optional (IO | str)** - Path to API key file or file-like object
-    - **base_url | (str)** - The base URL for REST requests. Default set to "https://api.coinbase.com"
+    - **base_url | (str)** - The base URL for REST requests. Default set to "https://api.coinbase.com" if *sandbox*
+      is False, otherwise "https://api-sandbox.coinbase.com"
     - **timeout | Optional (int)** - Set timeout in seconds for REST requests
     - **verbose | Optional (bool)** - Enables debug logging. Default set to False
     - **rate_limit_headers | Optional (bool)** - Enables rate limit headers. Default set to False
+    - **sandbox | bool** - Whether the target API is a sandbox and permits unauthenticated requests to otherwise
+      authenticated endpoints (see https://docs.cdp.coinbase.com/advanced-trade/docs/rest-api-sandbox for more
+      information). Default set to False
 
     """
 

--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -13,6 +13,7 @@ from coinbase.constants import (
     API_SECRET_ENV_KEY,
     BASE_URL,
     RATE_LIMIT_HEADERS,
+    SANDBOX_BASE_URL,
     USER_AGENT,
 )
 
@@ -57,11 +58,15 @@ class RESTBase(APIBase):
         api_key: Optional[str] = os.getenv(API_ENV_KEY),
         api_secret: Optional[str] = os.getenv(API_SECRET_ENV_KEY),
         key_file: Optional[Union[IO, str]] = None,
-        base_url=BASE_URL,
+        base_url: Optional[str] = None,
         timeout: Optional[int] = None,
         verbose: Optional[bool] = False,
         rate_limit_headers: Optional[bool] = False,
+        sandbox: bool = False,
     ):
+        if not base_url:
+            base_url = SANDBOX_BASE_URL if sandbox else BASE_URL
+
         super().__init__(
             api_key=api_key,
             api_secret=api_secret,
@@ -72,6 +77,7 @@ class RESTBase(APIBase):
         )
         self.rate_limit_headers = rate_limit_headers
         self.session = requests.Session()
+        self.sandbox = sandbox
         if verbose:
             logger.setLevel(logging.DEBUG)
 
@@ -191,7 +197,8 @@ class RESTBase(APIBase):
         """
         :meta private:
         """
-        if not self.is_authenticated and not public:
+
+        if not self.is_authenticated and (not public and not self.sandbox):
             raise AuthenticationError(
                 "Unauthenticated request to private endpoint. If you wish to access private endpoints, you must provide your API key and secret when initializing the RESTClient."
             )


### PR DESCRIPTION
This PR adds support for the (Coinbase Advanced Trade API Sandbox](https://docs.cdp.coinbase.com/advanced-trade/docs/rest-api-sandbox) by

1. Adding a `sandbox` parameter to the `RESTBase` constructor.
2. Using that, if enabled, to let requests to unauthenticated to otherwise authenticated endpoints pass.
3. Falling back to the `https://api-sandbox.coinbase.com` base URL if `sandbox` is set to `True` and no explicit base URL is specified.
