### PR TITLE
fix: guard against None values in response unpacking

### DIFF
--- a/coinbase/rest/types/futures_types.py
+++ b/coinbase/rest/types/futures_types.py
@@ -7,7 +7,7 @@ from coinbase.rest.types.common_types import Amount
 # Get Futures Balance Summary
 class GetFuturesBalanceSummaryResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "balance_summary" in response:
+        if "balance_summary" in response and response["balance_summary"] is not None:
             self.balance_summary: Optional[FCMBalanceSummary] = FCMBalanceSummary(
                 **response.pop("balance_summary")
             )
@@ -17,7 +17,7 @@ class GetFuturesBalanceSummaryResponse(BaseResponse):
 # List Futures Positions
 class ListFuturesPositionsResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "positions" in response:
+        if "positions" in response and response["positions"] is not None:
             self.positions: Optional[List[FCMPosition]] = [
                 FCMPosition(**position) for position in response.pop("positions")
             ]
@@ -27,7 +27,7 @@ class ListFuturesPositionsResponse(BaseResponse):
 # Get Futures Position
 class GetFuturesPositionResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "position" in response:
+        if "position" in response and response["position"] is not None:
             self.position: Optional[FCMPosition] = FCMPosition(
                 **response.pop("position")
             )
@@ -45,7 +45,7 @@ class ScheduleFuturesSweepResponse(BaseResponse):
 # List Futures Sweeps
 class ListFuturesSweepsResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "sweeps" in response:
+        if "sweeps" in response and response["sweeps"] is not None:
             self.sweeps: List[FCMSweep] = [
                 FCMSweep(**sweep) for sweep in response.pop("sweeps")
             ]

--- a/coinbase/rest/types/perpetuals_types.py
+++ b/coinbase/rest/types/perpetuals_types.py
@@ -13,12 +13,12 @@ class AllocatePortfolioResponse(BaseResponse):
 # Get Perpetuals Portfolio Summary
 class GetPerpetualsPortfolioSummaryResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "portfolios" in response:
+        if "portfolios" in response and response["portfolios"] is not None:
             self.portfolios: Optional[List[PerpetualPortfolio]] = [
                 PerpetualPortfolio(**portfolio)
                 for portfolio in response.pop("portfolios")
             ]
-        if "summary" in response:
+        if "summary" in response and response["summary"] is not None:
             self.summary: Optional[PortfolioSummary] = PortfolioSummary(
                 **response.pop("summary")
             )
@@ -28,11 +28,11 @@ class GetPerpetualsPortfolioSummaryResponse(BaseResponse):
 # List Perpetuals Positions
 class ListPerpetualsPositionsResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "positions" in response:
+        if "positions" in response and response["positions"] is not None:
             self.positions: Optional[List[Position]] = [
                 Position(**pos) for pos in response.pop("positions")
             ]
-        if "summary" in response:
+        if "summary" in response and response["summary"] is not None:
             self.summary: Optional[PositionSummary] = PositionSummary(
                 **response.pop("summary")
             )
@@ -42,7 +42,7 @@ class ListPerpetualsPositionsResponse(BaseResponse):
 # Get Perpetuals Position
 class GetPerpetualsPositionResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "position" in response:
+        if "position" in response and response["position"] is not None:
             self.position: Optional[Position] = Position(**response.pop("position"))
         super().__init__(**response)
 
@@ -50,7 +50,7 @@ class GetPerpetualsPositionResponse(BaseResponse):
 # Get Portfolio Balances
 class GetPortfolioBalancesResponse(BaseResponse):
     def __init__(self, response: dict):
-        if "portfolio_balances" in response:
+        if "portfolio_balances" in response and response["portfolio_balances"] is not None:
             self.portfolio_balances: Optional[List[PortfolioBalance]] = [
                 PortfolioBalance(**balance)
                 for balance in response.pop("portfolio_balances")


### PR DESCRIPTION
## Summary

- Add `is not None` checks before unpacking response values with `**` in `futures_types.py` and `perpetuals_types.py`
- When the API returns `{"position": null}`, the existing `if "key" in response` check passes but `**response.pop("key")` raises `TypeError` because `None` is not a mapping
- Applied defensively to all similar patterns across both files (positions, summaries, balances, sweeps)

Fixes #108