### PR TITLE
fix: cache parsed PEM private key to avoid re-parsing per request

### DIFF
--- a/coinbase/api_base.py
+++ b/coinbase/api_base.py
@@ -3,6 +3,8 @@ import logging
 import os
 from typing import IO, Optional, Union
 
+from cryptography.hazmat.primitives import serialization
+
 from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY
 
 
@@ -46,12 +48,20 @@ class APIBase(object):
                 raise Exception(f"Error decoding JSON: {e}")
 
         self.is_authenticated = False
+        self._private_key = None
         if api_key is not None and api_secret is not None:
             self.api_key = api_key
             self.api_secret = bytes(api_secret, encoding="utf8").decode(
                 "unicode_escape"
             )
             self.is_authenticated = True
+            try:
+                self._private_key = serialization.load_pem_private_key(
+                    self.api_secret.encode("utf-8"), password=None
+                )
+            except (ValueError, TypeError):
+                # Defer error to build_jwt where it's already handled
+                pass
         elif api_key is not None:
             raise Exception(
                 f"Only api_key provided in constructor. Please also provide api_secret"

--- a/coinbase/jwt_generator.py
+++ b/coinbase/jwt_generator.py
@@ -7,21 +7,22 @@ from cryptography.hazmat.primitives import serialization
 from coinbase.constants import BASE_URL
 
 
-def build_jwt(key_var, secret_var, uri=None) -> str:
+def build_jwt(key_var, secret_var, uri=None, private_key=None) -> str:
     """
     :meta private:
     """
-    try:
-        private_key_bytes = secret_var.encode("utf-8")
-        private_key = serialization.load_pem_private_key(
-            private_key_bytes, password=None
-        )
-    except ValueError as e:
-        # This handles errors like incorrect key format
-        raise Exception(
-            f"{e}\n"
-            "Are you sure you generated your key at https://cloud.coinbase.com/access/api ?"
-        )
+    if private_key is None:
+        try:
+            private_key_bytes = secret_var.encode("utf-8")
+            private_key = serialization.load_pem_private_key(
+                private_key_bytes, password=None
+            )
+        except ValueError as e:
+            # This handles errors like incorrect key format
+            raise Exception(
+                f"{e}\n"
+                "Are you sure you generated your key at https://cloud.coinbase.com/access/api ?"
+            )
 
     jwt_data = {
         "sub": key_var,
@@ -43,7 +44,7 @@ def build_jwt(key_var, secret_var, uri=None) -> str:
     return jwt_token
 
 
-def build_rest_jwt(uri, key_var, secret_var) -> str:
+def build_rest_jwt(uri, key_var, secret_var, private_key=None) -> str:
     """
     **Build REST JWT**
     __________
@@ -59,11 +60,12 @@ def build_rest_jwt(uri, key_var, secret_var) -> str:
     - **uri (str)** - Formatted URI for the endpoint (e.g. "GET api.coinbase.com/api/v3/brokerage/accounts") Can be generated using ``format_jwt_uri``
     - **key_var (str)** - The API key
     - **secret_var (str)** - The API key secret
+    - **private_key** - Optional pre-parsed private key to avoid re-parsing on every call
     """
-    return build_jwt(key_var, secret_var, uri=uri)
+    return build_jwt(key_var, secret_var, uri=uri, private_key=private_key)
 
 
-def build_ws_jwt(key_var, secret_var) -> str:
+def build_ws_jwt(key_var, secret_var, private_key=None) -> str:
     """
     **Build WebSocket JWT**
     __________
@@ -78,8 +80,9 @@ def build_ws_jwt(key_var, secret_var) -> str:
 
     - **key_var (str)** - The API key
     - **secret_var (str)** - The API key secret
+    - **private_key** - Optional pre-parsed private key to avoid re-parsing on every call
     """
-    return build_jwt(key_var, secret_var)
+    return build_jwt(key_var, secret_var, private_key=private_key)
 
 
 def format_jwt_uri(method, path) -> str:

--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -252,7 +252,7 @@ class RESTBase(APIBase):
             "Content-Type": "application/json",
             **(
                 {
-                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret)}",
+                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret, private_key=self._private_key)}",
                 }
                 if self.is_authenticated
                 else {}

--- a/coinbase/websocket/websocket_base.py
+++ b/coinbase/websocket/websocket_base.py
@@ -558,7 +558,7 @@ class WSBase(APIBase):
             "channel": channel,
             **(
                 {
-                    "jwt": jwt_generator.build_ws_jwt(self.api_key, self.api_secret),
+                    "jwt": jwt_generator.build_ws_jwt(self.api_key, self.api_secret, private_key=self._private_key),
                 }
                 if self.is_authenticated
                 else {}


### PR DESCRIPTION
## Summary

- Parse the PEM private key once in `APIBase.__init__()` instead of on every request
- Pass the cached key through `build_rest_jwt()` and `build_ws_jwt()` via an optional `private_key` parameter
- Backward-compatible: callers that don't pass `private_key` get the original parsing behavior
- Avoids redundant `load_pem_private_key()` ASN.1/DER parsing on every HTTP request

Fixes #121