### PR TITLE
Security: Prevent client-side DoS by adding default timeout to REST client

### DIFF
--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -58,7 +58,7 @@ class RESTBase(APIBase):
         api_secret: Optional[str] = os.getenv(API_SECRET_ENV_KEY),
         key_file: Optional[Union[IO, str]] = None,
         base_url=BASE_URL,
-        timeout: Optional[int] = None,
+        timeout: Optional[int] = 10,
         verbose: Optional[bool] = False,
         rate_limit_headers: Optional[bool] = False,
     ):
@@ -223,7 +223,7 @@ class RESTBase(APIBase):
             params=params,
             json=data,
             headers=headers,
-            timeout=self.timeout,
+            timeout=self.timeout if self.timeout is not None else 10,
         )
         handle_exception(response)  # Raise an HTTPError for bad responses
 


### PR DESCRIPTION
**Target:** `github.com/coinbase/coinbase-advanced-py` (Coinbase Advanced Python SDK)
**Vulnerability Type:** Denial of Service (DoS)

## Description
While using the official Coinbase Advanced Python SDK, a vulnerability exists in how it handles HTTP requests. The SDK uses the popular `requests` library to make API calls to Coinbase but fails to set a default timeout. 

In Python's `requests` library, if `timeout` is left as `None`, the application will wait **indefinitely** for a response. If the Coinbase API experiences an outage, or if network traffic is interrupted, the developer's entire application will hang permanently, leading to a complete Denial of Service (DoS).

## Proof of Concept in the Code
In [coinbase/rest/rest_base.py](cci:7://file:///c:/bugBounty/coinbase-advanced-py/coinbase/rest/rest_base.py:0:0-0:0), the `timeout` argument in the initialization of the `RESTClient` defaults to `None`. This variable is then passed directly as `timeout=self.timeout` to the `requests` library:

```python
response = self.session.request(
    http_method,
    url,
    params=params,
    json=data,
    headers=headers,
    timeout=self.timeout, # <--- Will be None, causing infinite hang
)
