### PR TITLE
fix: cache parsed PEM private key to avoid re-parsing per request

### DIFF
--- a/coinbase/api_base.py
+++ b/coinbase/api_base.py
@@ -3,6 +3,8 @@ import logging
 import os
 from typing import IO, Optional, Union
 
+from cryptography.hazmat.primitives import serialization
+
 from coinbase.constants import API_ENV_KEY, API_SECRET_ENV_KEY
 
 
@@ -46,12 +48,20 @@ class APIBase(object):
                 raise Exception(f"Error decoding JSON: {e}")
 
         self.is_authenticated = False
+        self._private_key = None
         if api_key is not None and api_secret is not None:
             self.api_key = api_key
             self.api_secret = bytes(api_secret, encoding="utf8").decode(
                 "unicode_escape"
             )
             self.is_authenticated = True
+            try:
+                self._private_key = serialization.load_pem_private_key(
+                    self.api_secret.encode("utf-8"), password=None
+                )
+            except (TypeError, ValueError):
+                # Preserve current constructor behavior for placeholder or invalid keys.
+                pass
         elif api_key is not None:
             raise Exception(
                 f"Only api_key provided in constructor. Please also provide api_secret"

--- a/coinbase/jwt_generator.py
+++ b/coinbase/jwt_generator.py
@@ -7,21 +7,22 @@ from cryptography.hazmat.primitives import serialization
 from coinbase.constants import BASE_URL
 
 
-def build_jwt(key_var, secret_var, uri=None) -> str:
+def build_jwt(key_var, secret_var, uri=None, private_key=None) -> str:
     """
     :meta private:
     """
-    try:
-        private_key_bytes = secret_var.encode("utf-8")
-        private_key = serialization.load_pem_private_key(
-            private_key_bytes, password=None
-        )
-    except ValueError as e:
-        # This handles errors like incorrect key format
-        raise Exception(
-            f"{e}\n"
-            "Are you sure you generated your key at https://cloud.coinbase.com/access/api ?"
-        )
+    if private_key is None:
+        try:
+            private_key_bytes = secret_var.encode("utf-8")
+            private_key = serialization.load_pem_private_key(
+                private_key_bytes, password=None
+            )
+        except ValueError as e:
+            # This handles errors like incorrect key format
+            raise Exception(
+                f"{e}\n"
+                "Are you sure you generated your key at https://cloud.coinbase.com/access/api ?"
+            )
 
     jwt_data = {
         "sub": key_var,
@@ -43,7 +44,7 @@ def build_jwt(key_var, secret_var, uri=None) -> str:
     return jwt_token
 
 
-def build_rest_jwt(uri, key_var, secret_var) -> str:
+def build_rest_jwt(uri, key_var, secret_var, private_key=None) -> str:
     """
     **Build REST JWT**
     __________
@@ -59,11 +60,12 @@ def build_rest_jwt(uri, key_var, secret_var) -> str:
     - **uri (str)** - Formatted URI for the endpoint (e.g. "GET api.coinbase.com/api/v3/brokerage/accounts") Can be generated using ``format_jwt_uri``
     - **key_var (str)** - The API key
     - **secret_var (str)** - The API key secret
+    - **private_key** - Optional pre-parsed private key to avoid re-parsing
     """
-    return build_jwt(key_var, secret_var, uri=uri)
+    return build_jwt(key_var, secret_var, uri=uri, private_key=private_key)
 
 
-def build_ws_jwt(key_var, secret_var) -> str:
+def build_ws_jwt(key_var, secret_var, private_key=None) -> str:
     """
     **Build WebSocket JWT**
     __________
@@ -78,8 +80,9 @@ def build_ws_jwt(key_var, secret_var) -> str:
 
     - **key_var (str)** - The API key
     - **secret_var (str)** - The API key secret
+    - **private_key** - Optional pre-parsed private key to avoid re-parsing
     """
-    return build_jwt(key_var, secret_var)
+    return build_jwt(key_var, secret_var, private_key=private_key)
 
 
 def format_jwt_uri(method, path) -> str:

--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -252,7 +252,7 @@ class RESTBase(APIBase):
             "Content-Type": "application/json",
             **(
                 {
-                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret)}",
+                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret, private_key=self._private_key)}",
                 }
                 if self.is_authenticated
                 else {}

--- a/coinbase/websocket/websocket_base.py
+++ b/coinbase/websocket/websocket_base.py
@@ -558,7 +558,11 @@ class WSBase(APIBase):
             "channel": channel,
             **(
                 {
-                    "jwt": jwt_generator.build_ws_jwt(self.api_key, self.api_secret),
+                    "jwt": jwt_generator.build_ws_jwt(
+                        self.api_key,
+                        self.api_secret,
+                        private_key=self._private_key,
+                    ),
                 }
                 if self.is_authenticated
                 else {}

--- a/tests/rest/test_rest_base.py
+++ b/tests/rest/test_rest_base.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from requests.exceptions import HTTPError
 from requests_mock import Mocker
@@ -10,6 +11,21 @@ from ..constants import TEST_API_KEY, TEST_API_SECRET
 
 
 class RestBaseTest(unittest.TestCase):
+    @patch("coinbase.rest.rest_base.jwt_generator.build_rest_jwt", return_value="signed-jwt")
+    def test_set_headers_uses_cached_private_key(self, mock_build_rest_jwt):
+        client = RESTClient(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+
+        headers = client.set_headers("GET", "/api/v3/brokerage/accounts")
+
+        self.assertIsNotNone(client._private_key)
+        self.assertEqual(headers["Authorization"], "Bearer signed-jwt")
+        mock_build_rest_jwt.assert_called_once_with(
+            "GET api.coinbase.com/api/v3/brokerage/accounts",
+            TEST_API_KEY,
+            TEST_API_SECRET,
+            private_key=client._private_key,
+        )
+
     def test_get(self):
         client = RESTClient(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
 

--- a/tests/test_jwt_generator.py
+++ b/tests/test_jwt_generator.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import unittest
+from unittest.mock import patch
 
 import jwt
 
@@ -39,3 +40,36 @@ class JwtGeneratorTest(unittest.TestCase):
         with self.assertRaises(Exception):
             uri = jwt_generator.format_jwt_uri("GET", "/api/v3/brokerage/accounts")
             jwt_generator.build_rest_jwt(uri, TEST_API_KEY, "bad_secret")
+
+    @patch("coinbase.jwt_generator.jwt.encode", return_value="signed-jwt")
+    @patch("coinbase.jwt_generator.serialization.load_pem_private_key")
+    def test_build_rest_jwt_with_preparsed_key(
+        self, mock_load_private_key, mock_jwt_encode
+    ):
+        private_key = object()
+        uri = jwt_generator.format_jwt_uri("GET", "/api/v3/brokerage/accounts")
+
+        result_jwt = jwt_generator.build_rest_jwt(
+            uri, TEST_API_KEY, TEST_API_SECRET, private_key=private_key
+        )
+
+        mock_load_private_key.assert_not_called()
+        self.assertEqual(result_jwt, "signed-jwt")
+        self.assertEqual(mock_jwt_encode.call_args.args[1], private_key)
+        self.assertEqual(mock_jwt_encode.call_args.kwargs["algorithm"], "ES256")
+
+    @patch("coinbase.jwt_generator.jwt.encode", return_value="signed-jwt")
+    @patch("coinbase.jwt_generator.serialization.load_pem_private_key")
+    def test_build_ws_jwt_with_preparsed_key(
+        self, mock_load_private_key, mock_jwt_encode
+    ):
+        private_key = object()
+
+        result_jwt = jwt_generator.build_ws_jwt(
+            TEST_API_KEY, TEST_API_SECRET, private_key=private_key
+        )
+
+        mock_load_private_key.assert_not_called()
+        self.assertEqual(result_jwt, "signed-jwt")
+        self.assertEqual(mock_jwt_encode.call_args.args[1], private_key)
+        self.assertEqual(mock_jwt_encode.call_args.kwargs["algorithm"], "ES256")

--- a/tests/websocket/test_websocket_base.py
+++ b/tests/websocket/test_websocket_base.py
@@ -47,6 +47,20 @@ class WSBaseTest(unittest.IsolatedAsyncioTestCase):
             retry=False,
         )
 
+    @patch("coinbase.websocket.websocket_base.jwt_generator.build_ws_jwt", return_value="signed-jwt")
+    def test_subscription_message_uses_cached_private_key(self, mock_build_ws_jwt):
+        message = self.ws._build_subscription_message(
+            ["BTC-USD"], "ticker", SUBSCRIBE_MESSAGE_TYPE, public=False
+        )
+
+        self.assertIsNotNone(self.ws._private_key)
+        self.assertEqual(message["jwt"], "signed-jwt")
+        mock_build_ws_jwt.assert_called_once_with(
+            TEST_API_KEY,
+            TEST_API_SECRET,
+            private_key=self.ws._private_key,
+        )
+
     @patch("websockets.connect", new_callable=AsyncMock)
     def test_open_twice(self, mock_connect):
         # assert you cannot open a websocket client twice consecutively


### PR DESCRIPTION
## Summary
- parse the PEM private key once in `APIBase.__init__()` and cache the loaded key when possible
- pass the cached key through REST and WebSocket JWT builders instead of re-parsing on every token
- preserve constructor behavior for placeholder or invalid secrets by falling back to the existing parse-on-demand path
- add focused regression coverage for JWT helper reuse plus REST and WebSocket wiring

## Context
This replays #124, which was approved on March 6, 2026 but later closed on March 21, 2026 after the original head repo was deleted.

From the public timeline, that earlier approval appears to have been invalidated by Coinbase's Heimdall MFA gate on the reviewer account, so I'm reopening the same fix from a live fork for fresh review.

## Testing
- `python -m pytest tests/test_api_base.py tests/test_jwt_generator.py tests/rest/test_rest_base.py`
- `python -m pytest tests/websocket/test_websocket_base.py::WSBaseTest::test_subscription_message_uses_cached_private_key`
