### PR TITLE
Modernize CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build and Test
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   format-code:
@@ -8,11 +16,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies and format code
       run: |
-        sudo apt-get install -y make
         pip3 install -r lint_requirements.txt
         make format
 
@@ -27,14 +34,19 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Set up Python environment
-      uses: actions/setup-python@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies and run tests
       run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           pip3 install -r pinned_requirements.txt
@@ -39,12 +39,12 @@ jobs:
           cd docs
           make html
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload the build output directory
           path: 'docs/_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What

**Pages (`pages.yml`)**
- `configure-pages@v3` → `@v5`
- `upload-pages-artifact@v1` → `@v3`
- `deploy-pages@v2` → `@v4`
- `checkout@v3` → `@v4`

**Build (`build.yml`)**
- `checkout@v3` → `@v4`, `setup-python@v3` → `@v5`
- Run tests across the full supported Python range (3.8–3.11) via a matrix, instead of only 3.9 (the SDK declares `python_requires=">=3.8"`).
- Added a `concurrency` group to cancel superseded runs.
- Trigger on `pull_request` too, so contributor PRs get tested (was `push`-only).
- Dropped the redundant `sudo apt-get install -y make` (make is preinstalled on `ubuntu-latest`).