### PR TITLE
Cache REST JWT private key

### DIFF
--- a/coinbase/jwt_generator.py
+++ b/coinbase/jwt_generator.py
@@ -39,17 +39,21 @@ def _algorithm_for(private_key) -> str:
     )
 
 
-def build_jwt(key_var, secret_var, uri=None) -> str:
-    """
-    :meta private:
-    """
+def _load_private_key_for_jwt(secret_var):
     try:
-        private_key = _load_private_key(secret_var)
+        return _load_private_key(secret_var)
     except (ValueError, TypeError) as e:
         raise Exception(
             f"{e}\n"
             "Are you sure you generated your key at https://cloud.coinbase.com/access/api ?"
         )
+
+
+def build_jwt(key_var, secret_var, uri=None, private_key=None) -> str:
+    """
+    :meta private:
+    """
+    private_key = private_key or _load_private_key_for_jwt(secret_var)
 
     jwt_data = {
         "sub": key_var,
@@ -71,7 +75,7 @@ def build_jwt(key_var, secret_var, uri=None) -> str:
     return jwt_token
 
 
-def build_rest_jwt(uri, key_var, secret_var) -> str:
+def build_rest_jwt(uri, key_var, secret_var, private_key=None) -> str:
     """
     **Build REST JWT**
     __________
@@ -88,7 +92,7 @@ def build_rest_jwt(uri, key_var, secret_var) -> str:
     - **key_var (str)** - The API key
     - **secret_var (str)** - The API key secret
     """
-    return build_jwt(key_var, secret_var, uri=uri)
+    return build_jwt(key_var, secret_var, uri=uri, private_key=private_key)
 
 
 def build_ws_jwt(key_var, secret_var) -> str:

--- a/coinbase/rest/rest_base.py
+++ b/coinbase/rest/rest_base.py
@@ -72,6 +72,7 @@ class RESTBase(APIBase):
         )
         self.rate_limit_headers = rate_limit_headers
         self.session = requests.Session()
+        self._private_key = None
         if verbose:
             logger.setLevel(logging.DEBUG)
 
@@ -252,9 +253,17 @@ class RESTBase(APIBase):
             "Content-Type": "application/json",
             **(
                 {
-                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret)}",
+                    "Authorization": f"Bearer {jwt_generator.build_rest_jwt(uri, self.api_key, self.api_secret, private_key=self._get_private_key())}",
                 }
                 if self.is_authenticated
                 else {}
             ),
         }
+
+    def _get_private_key(self):
+        """
+        :meta private:
+        """
+        if self._private_key is None:
+            self._private_key = jwt_generator._load_private_key_for_jwt(self.api_secret)
+        return self._private_key

--- a/tests/rest/test_rest_base.py
+++ b/tests/rest/test_rest_base.py
@@ -1,8 +1,10 @@
 import unittest
+from unittest.mock import patch
 
 from requests.exceptions import HTTPError
 from requests_mock import Mocker
 
+from coinbase import jwt_generator
 from coinbase.__version__ import __version__
 from coinbase.rest import RESTClient
 
@@ -92,6 +94,19 @@ class RestBaseTest(unittest.TestCase):
                     captured_headers["User-Agent"],
                     "coinbase-advanced-py/" + __version__,
                 )
+
+    def test_authenticated_client_reuses_parsed_private_key(self):
+        client = RESTClient(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+
+        with patch.object(
+            jwt_generator,
+            "_load_private_key",
+            wraps=jwt_generator._load_private_key,
+        ) as load_private_key:
+            client.set_headers("GET", "/api/v3/brokerage/accounts")
+            client.set_headers("GET", "/api/v3/brokerage/orders")
+
+        self.assertEqual(load_private_key.call_count, 1)
 
     def test_post(self):
         client = RESTClient(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)


### PR DESCRIPTION
## Summary

- Add an optional parsed private key path through the JWT generator helpers.
- Lazily parse and cache the REST client's PEM private key once, then reuse it for subsequent REST JWT signing.
- Add regression coverage that repeated authenticated header generation only parses the PEM key once.

Fixes #121.

## Validation

- `black --check coinbase\jwt_generator.py coinbase\rest\rest_base.py tests\rest\test_rest_base.py`
- `.venv\Scripts\python -m unittest tests.rest.test_rest_base tests.test_jwt_generator -v` — `OK`
- `.venv\Scripts\python -m unittest discover -v` — `Ran 174 tests`, `OK`
- `git diff --check`
